### PR TITLE
Rewrite get_temp with libsensors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC       := clang
 CPPFLAGS += `pkg-config --cflags-only-I x11 fontconfig alsa`
 CFLAGS   += -Wall -Wextra -Werror -O2 `pkg-config --cflags-only-other x11 fontconfig alsa`
-LDFLAGS  += `pkg-config --libs x11 fontconfig alsa`
+LDFLAGS  += `pkg-config --libs x11 fontconfig alsa` -lsensors
 PROGRAM   = dmenustatus
 
 


### PR DESCRIPTION
Rewrote the get_temp function to use the libsensors library `-lsensors`. It now iterates thru chips to find a label for `"CPU Temperature"` and retrieve its value.